### PR TITLE
Do 4095 adding timeout customization support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,11 @@ resource "google_redis_instance" "default" {
       rdb_snapshot_period = persistence_config.value["rdb_snapshot_period"]
     }
   }
+  timeouts {
+    create = var.redis_create_timeout
+    update = var.redis_update_timeout
+    delete = var.redis_delete_timeout
+  }
 }
 
 module "enable_apis" {

--- a/variables.tf
+++ b/variables.tf
@@ -161,3 +161,18 @@ variable "persistence_config" {
   })
   default = null
 }
+
+variable "redis_create_timeout" {
+  description = "Timeout for creating a redis memorystore instance"
+  default     = "40m"
+}
+
+variable "redis_update_timeout" {
+  description = "Timeout for updating a redis memorystore instance"
+  default     = "40m"
+}
+
+variable "redis_delete_timeout" {
+  description = "Timeout for deleting a redis memorystore instance"
+  default     = "40m"
+}


### PR DESCRIPTION
Adding support for customizing timeout values for redis operation, and doubling the default timeout from 20m to 40m